### PR TITLE
Fix for issue #93, in which blank lines are indented when a selection of...

### DIFF
--- a/kaa/commands/editorcommand.py
+++ b/kaa/commands/editorcommand.py
@@ -622,8 +622,10 @@ class EditCommands(Commands):
                 else:
                     cols = 0
 
-                s = mode.build_indent_str(cols + mode.indent_width)
-                self.replace_string(wnd, f, t, s, False)
+                eol = doc.geteol(tol)
+                if eol != t+1:
+                    s = mode.build_indent_str(cols + mode.indent_width)
+                    self.replace_string(wnd, f, t, s, False)
                 tol = doc.geteol(tol)
         finally:
             if wnd.document.undo:

--- a/test/test_editorcommands.py
+++ b/test/test_editorcommands.py
@@ -75,6 +75,13 @@ class TestEdit(kaa_testutils._TestScreenBase):
         cmd.indent(wnd)
         assert wnd.document.gettext(0, 7) == '    abc'
 
+    def test_blockindentblanklines(self):
+        wnd = self._getwnd("abc\n\ndef method")
+        wnd.screen.selection.set_range(1, 6)
+        cmd = editorcommand.EditCommands()
+        cmd.indent(wnd)
+        assert wnd.document.gettext(0, 16) == "    abc\n\n    def"
+
     def test_undo_ins(self):
         wnd = self._getwnd("")
         cmd = editorcommand.EditCommands()


### PR DESCRIPTION
... lines are indented. This prevents that and adds a regression test for it to test_editorcommands.py

Given your comments on issue #93 I thought it best to submit now a pull request for the fix I have. Separate to this I can investigate as to whether it would be fruitful to implement `indent` in terms of `_indent_line`.
