### PR TITLE
Fixed to show F5 keybind after running macro:

### DIFF
--- a/kaa/macro.py
+++ b/kaa/macro.py
@@ -9,6 +9,8 @@ class Macro:
     recording = False
     commands = ()
 
+    RERUN_MACRO_MESSAGE = "Type F5 to run the macro again."
+
     def start_record(self):
         self.recording = True
         self.commands = []
@@ -59,3 +61,4 @@ class Macro:
                         cmd(wnd, *args, **kwargs)
                 finally:
                     wnd.set_command_repeat(1)
+        kaa.app.messagebar.set_message(self.RERUN_MACRO_MESSAGE)


### PR DESCRIPTION
In most cases, users will want to run the macro again and again.
But at the first time to run it, I always run it from menu.
Cause I dont remember the keybind. Showing it as a message is cool.